### PR TITLE
Adicionando responsividade

### DIFF
--- a/css/cabecalho_e_navegacao.css
+++ b/css/cabecalho_e_navegacao.css
@@ -46,7 +46,7 @@
 .cargo {
   font-size: 1.25rem;
   margin-bottom: 30px;
-  font-weight: 700;
+  opacity: 0.9;
 }
 
 /* ===== NAVEGAÇÃO ===== */

--- a/css/cabecalho_e_navegacao.css
+++ b/css/cabecalho_e_navegacao.css
@@ -58,8 +58,8 @@
   display: none;
   flex-direction: column;
   cursor: pointer;
-  width: 40px;
-  height: 30px;
+  width: 30px;
+  height: 20px;
   justify-content: space-between;
   padding: 5px;
   position: absolute;

--- a/css/responsividade.css
+++ b/css/responsividade.css
@@ -42,6 +42,10 @@
         font-size: 2rem;
     }
 
+    .cargo {
+        font-size: 1.1rem;
+    }
+
     .foto-perfil {
         width: 120px;
         height: 120px;
@@ -55,6 +59,10 @@
 
     .nome {
         font-size: 1.6rem;
+    }
+
+    .cargo {
+        font-size: 1rem;
     }
 
     h2 {

--- a/css/responsividade.css
+++ b/css/responsividade.css
@@ -1,0 +1,65 @@
+@media (max-width: 768px) {
+    .menu-toggle {
+        display: flex;
+    }
+
+    .navegacao {
+        display: none;
+        /* flex-direction: column;
+        width: 100%; */
+        margin-top: 20px;
+        background: rgba(255, 255, 255, 0.1);
+        padding: 20px;
+        border-radius: 10px;
+        align-items: center;
+    }
+
+    /* Faz o menu aparecer quando o checkbox está marcado */
+    .menu-checkbox:checked ~ .navegacao {
+        display: flex;
+    }
+
+    .navegacao a {
+        width: 100%;
+        text-align: center;
+    }
+
+    /* .sobre-conteudo,
+    .contato-conteudo {
+        grid-template-columns: 1fr;
+        gap: 30px;
+    }
+    
+    .imagem-contato {
+        max-height: 300px;
+    }
+    
+    .grade-premiacoes {
+        grid-template-columns: 1fr;
+    } */
+
+    .nome {
+        font-size: 2rem;
+    }
+
+    .foto-perfil {
+        width: 120px;
+        height: 120px;
+    }
+}
+
+@media (max-width: 480px) {
+    .container {
+        padding: 0 15px;
+    }
+
+    .nome {
+        font-size: 1.6rem;
+    }
+
+    h2 {
+        font-size: 1.6rem;
+    }
+
+
+}

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Silvio Nascimento Ribeiro</title>
     <link rel="stylesheet" href="/css/main.css">
     <link rel="stylesheet" href="/css/cabecalho_e_navegacao.css" />
+    <link rel="stylesheet" href="/css/responsividade.css">
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
Bom dia. Ao invés de adicionar a responsividade no arquivo cabecalho_e_navegacao.css, a qual foi informado na issue #3, foi desenvolvido um arquivo responsável pela responsividade global do portfólio. Na imagem abaixo mostra onde este arquivo está localizado:

<img width="305" height="187" alt="image" src="https://github.com/user-attachments/assets/a1e8623a-4eef-4a6d-ab27-3bb191b17d0d" />
